### PR TITLE
Add option to load preimages from a directory

### DIFF
--- a/preimage-server/src/cli.rs
+++ b/preimage-server/src/cli.rs
@@ -5,6 +5,6 @@ use clap::Parser;
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
-    /// Path to pre-image file to load
-    pub file: PathBuf,
+    /// Path to pre-image json file to load or directory to scan
+    pub path: PathBuf,
 }


### PR DESCRIPTION
Allow the CLI to load from a directory of files or a json file depending on what is passed as an argument