### PR TITLE
Fixed division operations.

### DIFF
--- a/Dockerfile.cannon-builder
+++ b/Dockerfile.cannon-builder
@@ -31,6 +31,6 @@ COPY mips-unknown-none.json .
 ENV CC_mips_unknown_none=mips-linux-gnu-gcc \
     CXX_mips_unknown_none=mips-linux-gnu-g++ \
     CARGO_TARGET_MIPS_UNKNOWN_NONE_LINKER=mips-linux-gnu-gcc \
-    RUSTFLAGS="-Clink-arg=-e_start" \
+    RUSTFLAGS="-Clink-arg=-e_start -C llvm-args=-mno-check-zero-division" \
     CARGO_BUILD_TARGET="/mips-unknown-none.json" \
     RUSTUP_TOOLCHAIN=${RUST_VERSION}


### PR DESCRIPTION
Hi. Great project!
I ran into a problem with division. Some division operation caused an 'invalid instruction' error.
After looking into it, I discovered that the issue is related to Rust using a specific instruction called 'teq'. However, this instruction, along with other trap instructions, is not supported in cannon.
To fix this, I added a flag that tells LLVM, the compiler, to avoid using traps for division checks.